### PR TITLE
Implement statistics helpers and optimizer utilities

### DIFF
--- a/server/innodb/plan/index_merge_test.go
+++ b/server/innodb/plan/index_merge_test.go
@@ -1,0 +1,69 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatisticsHelpers(t *testing.T) {
+	now := getCurrentTime()
+	if now <= 0 {
+		t.Errorf("invalid time: %d", now)
+	}
+
+	if calculateValueSize(int64(1)) == 0 {
+		t.Error("size of int64 should be >0")
+	}
+
+	key := buildIndexKey([]interface{}{1, "a"})
+	if key != "1|a" {
+		t.Errorf("unexpected index key %s", key)
+	}
+
+	cf := calculateClusterFactor([][]interface{}{{1}, {1}, {2}})
+	if cf <= 0 {
+		t.Errorf("cluster factor not computed")
+	}
+
+	if !less(int64(1), int64(2)) {
+		t.Error("less failed for int64")
+	}
+}
+
+func TestIndexMergeCandidates(t *testing.T) {
+	table := createTestTable()
+	opt := NewIndexPushdownOptimizer()
+
+	conds := []Expression{
+		&BinaryOperation{Op: OpEQ, Left: &Column{Name: "id"}, Right: &Constant{Value: int64(1)}},
+		&BinaryOperation{Op: OpEQ, Left: &Column{Name: "email"}, Right: &Constant{Value: "a"}},
+	}
+
+	candidate, err := opt.OptimizeIndexAccess(table, conds, []string{"id", "email"})
+	if err != nil {
+		t.Fatalf("optimize failed: %v", err)
+	}
+	if candidate == nil || candidate.Index == nil || !strings.Contains(candidate.Index.Name, "+") {
+		t.Fatalf("expected merged index candidate, got %#v", candidate)
+	}
+}
+
+func TestIndexMergeFallbackSingle(t *testing.T) {
+	table := createTestTable()
+	opt := NewIndexPushdownOptimizer()
+
+	conds := []Expression{
+		&BinaryOperation{Op: OpEQ, Left: &Column{Name: "id"}, Right: &Constant{Value: int64(1)}},
+	}
+
+	candidate, err := opt.OptimizeIndexAccess(table, conds, []string{"id"})
+	if err != nil {
+		t.Fatalf("optimize failed: %v", err)
+	}
+	if candidate == nil || candidate.Index == nil {
+		t.Fatalf("no candidate")
+	}
+	if strings.Contains(candidate.Index.Name, "+") {
+		t.Fatalf("expected single index, got merged %s", candidate.Index.Name)
+	}
+}

--- a/server/innodb/plan/index_pushdown_optimizer.go
+++ b/server/innodb/plan/index_pushdown_optimizer.go
@@ -58,7 +58,11 @@ func (opt *IndexPushdownOptimizer) OptimizeIndexAccess(
 	// 2. 获取所有可用索引
 	candidates := opt.generateIndexCandidates(table, conditions, selectColumns)
 
-	// 3. 选择最优索引
+	// 2.1 合并索引候选
+	merged := opt.mergeCandidates(candidates)
+	candidates = append(candidates, merged...)
+
+	// 3. 选择最优索引或索引合并方案
 	bestCandidate := opt.selectBestIndex(candidates)
 
 	return bestCandidate, nil
@@ -248,6 +252,36 @@ func (opt *IndexPushdownOptimizer) evaluateIndex(
 	candidate.Cost = opt.calculateIndexCost(index, candidate)
 
 	return candidate
+}
+
+// mergeCandidates 生成合并索引候选
+func (opt *IndexPushdownOptimizer) mergeCandidates(candidates []*IndexCandidate) []*IndexCandidate {
+	var merged []*IndexCandidate
+	for i := 0; i < len(candidates); i++ {
+		for j := i + 1; j < len(candidates); j++ {
+			c1 := candidates[i]
+			c2 := candidates[j]
+			if c1 == nil || c2 == nil {
+				continue
+			}
+			// 简单合并，不考虑覆盖列冲突等
+			conds := append([]*IndexCondition{}, c1.Conditions...)
+			conds = append(conds, c2.Conditions...)
+			sel := c1.Selectivity * c2.Selectivity
+			mergedCandidate := &IndexCandidate{
+				Index: &metadata.Index{
+					Name: c1.Index.Name + "+" + c2.Index.Name,
+				},
+				Conditions:  conds,
+				CoverIndex:  c1.CoverIndex && c2.CoverIndex,
+				Cost:        c1.Cost + c2.Cost,
+				Selectivity: sel,
+				KeyLength:   c1.KeyLength + c2.KeyLength,
+			}
+			merged = append(merged, mergedCandidate)
+		}
+	}
+	return merged
 }
 
 // isCoveringIndex 检查是否为覆盖索引

--- a/server/innodb/plan/optimizer.go
+++ b/server/innodb/plan/optimizer.go
@@ -1,5 +1,11 @@
 package plan
 
+import (
+	"sort"
+
+	"github.com/zhukovaskychina/xmysql-server/server/innodb/metadata"
+)
+
 // OptimizeLogicalPlan 优化逻辑计划
 func OptimizeLogicalPlan(plan LogicalPlan) LogicalPlan {
 	// 1. 谓词下推
@@ -13,6 +19,10 @@ func OptimizeLogicalPlan(plan LogicalPlan) LogicalPlan {
 
 	// 4. 子查询优化
 	plan = optimizeSubquery(plan)
+
+	// 5. 索引访问优化
+	opt := NewIndexPushdownOptimizer()
+	plan = optimizeIndexAccess(plan, opt)
 
 	return plan
 }
@@ -174,37 +184,200 @@ func eliminateAggregation(plan LogicalPlan) LogicalPlan {
 
 // optimizeSubquery 子查询优化
 func optimizeSubquery(plan LogicalPlan) LogicalPlan {
-	// TODO: 实现子查询优化
-	// 1. 子查询去关联
-	// 2. 子查询展开
-	// 3. 子查询上拉
+	// 当前代码库尚未实现完整的子查询算子，这里仅递归处理子计划。
+	// 若将来增加了子查询相关的逻辑计划节点，可在此处实现去关联、
+	// 展开以及上拉等优化。
+
+	for i, child := range plan.Children() {
+		newChild := optimizeSubquery(child)
+		children := plan.Children()
+		children[i] = newChild
+		plan.SetChildren(children)
+	}
+
+	return plan
+}
+
+// optimizeIndexAccess 使用索引下推优化器选择索引
+func optimizeIndexAccess(plan LogicalPlan, optimizer *IndexPushdownOptimizer) LogicalPlan {
+	switch v := plan.(type) {
+	case *LogicalSelection:
+		child := v.Children()[0]
+		if ts, ok := child.(*LogicalTableScan); ok {
+			cand, err := optimizer.OptimizeIndexAccess(ts.Table, v.Conditions, []string{})
+			if err == nil && cand != nil {
+				newScan := &LogicalIndexScan{
+					BaseLogicalPlan: BaseLogicalPlan{schema: ts.Schema()},
+					Table:           ts.Table,
+					Index: &Index{
+						Name:    cand.Index.Name,
+						Columns: cand.Index.Columns,
+						Unique:  cand.Index.IsUnique,
+					},
+				}
+				return newScan
+			}
+		}
+	}
+
+	for i, child := range plan.Children() {
+		newChild := optimizeIndexAccess(child, optimizer)
+		children := plan.Children()
+		children[i] = newChild
+		plan.SetChildren(children)
+	}
 	return plan
 }
 
 // 辅助函数
 
+// mergePredicate merges predicate conditions into an existing selection node or
+// creates a new one on top of the given plan. It is used by predicate push down
+// to combine multiple filters.
 func mergePredicate(plan LogicalPlan, conditions []Expression) LogicalPlan {
-	// TODO: 合并谓词条件
-	return plan
+	if sel, ok := plan.(*LogicalSelection); ok {
+		sel.Conditions = append(sel.Conditions, conditions...)
+		return sel
+	}
+
+	return &LogicalSelection{
+		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{plan}},
+		Conditions:      conditions,
+	}
 }
 
 func splitJoinCondition(conditions []Expression, join *LogicalJoin) ([]Expression, []Expression, []Expression) {
-	// TODO: 分解连接条件
-	return nil, nil, conditions
+	var leftConds, rightConds, otherConds []Expression
+
+	for _, cond := range conditions {
+		cols := collectUsedColumns([]Expression{cond})
+		if len(cols) == 0 {
+			otherConds = append(otherConds, cond)
+			continue
+		}
+
+		allLeft := true
+		allRight := true
+		for _, c := range cols {
+			if join.LeftSchema == nil || !columnInSchema(join.LeftSchema, c) {
+				allLeft = false
+			}
+			if join.RightSchema == nil || !columnInSchema(join.RightSchema, c) {
+				allRight = false
+			}
+		}
+
+		switch {
+		case allLeft && !allRight:
+			leftConds = append(leftConds, cond)
+		case allRight && !allLeft:
+			rightConds = append(rightConds, cond)
+		default:
+			otherConds = append(otherConds, cond)
+		}
+	}
+
+	return leftConds, rightConds, otherConds
 }
 
 func collectUsedColumns(exprs []Expression) []string {
-	// TODO: 收集表达式中使用的列
-	return nil
+	colSet := make(map[string]struct{})
+	var collect func(Expression)
+
+	collect = func(e Expression) {
+		if e == nil {
+			return
+		}
+		switch v := e.(type) {
+		case *Column:
+			colSet[v.Name] = struct{}{}
+		case *BinaryOperation:
+			collect(v.Left)
+			collect(v.Right)
+		case *Function:
+			for _, arg := range v.Args {
+				collect(arg)
+			}
+		default:
+			for _, c := range e.Children() {
+				collect(c)
+			}
+		}
+	}
+
+	for _, expr := range exprs {
+		collect(expr)
+	}
+
+	cols := make([]string, 0, len(colSet))
+	for c := range colSet {
+		cols = append(cols, c)
+	}
+	sort.Strings(cols)
+	return cols
 }
 
 func updateOutputColumns(plan LogicalPlan, usedCols []string) {
-	// TODO: 更新计划节点的输出列
+	if len(usedCols) == 0 {
+		return
+	}
+
+	switch p := plan.(type) {
+	case *LogicalTableScan:
+		p.BaseLogicalPlan.schema = buildPrunedSchema(p.Table.Schema, usedCols)
+	case *LogicalIndexScan:
+		p.BaseLogicalPlan.schema = buildPrunedSchema(p.Table.Schema, usedCols)
+	case *LogicalSelection, *LogicalProjection, *LogicalAggregation:
+		if len(p.Children()) > 0 {
+			updateOutputColumns(p.Children()[0], usedCols)
+		}
+	case *LogicalJoin:
+		if len(p.Children()) >= 2 {
+			updateOutputColumns(p.Children()[0], usedCols)
+			updateOutputColumns(p.Children()[1], usedCols)
+		}
+	}
 }
 
 func collectAggFuncCols(funcs []AggregateFunc) []Expression {
-	// TODO: 收集聚合函数中使用的列
-	return nil
+	var exprs []Expression
+	for _, f := range funcs {
+		exprs = append(exprs, f.Args()...)
+	}
+	return exprs
+}
+
+// columnInSchema checks whether the given column exists in any table of the schema.
+func columnInSchema(schema *metadata.DatabaseSchema, col string) bool {
+	if schema == nil {
+		return false
+	}
+	for _, tbl := range schema.Tables {
+		if _, ok := tbl.GetColumn(col); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// buildPrunedSchema creates a new schema containing only the specified columns.
+// Columns that do not exist in the original schema are ignored.
+func buildPrunedSchema(schema *metadata.DatabaseSchema, cols []string) *metadata.DatabaseSchema {
+	if schema == nil {
+		return nil
+	}
+	newSchema := metadata.NewSchema(schema.Name)
+	for _, tbl := range schema.Tables {
+		newTbl := &metadata.Table{Name: tbl.Name, Indices: tbl.Indices, Stats: tbl.Stats}
+		for _, colName := range cols {
+			if col, ok := tbl.GetColumn(colName); ok {
+				cp := *col
+				newTbl.Columns = append(newTbl.Columns, &cp)
+			}
+		}
+		_ = newSchema.AddTable(newTbl)
+	}
+	return newSchema
 }
 
 func canEliminateAggregation(agg *LogicalAggregation, child LogicalPlan) bool {

--- a/server/innodb/plan/statistics.go
+++ b/server/innodb/plan/statistics.go
@@ -1,8 +1,11 @@
 package plan
 
 import (
+	"fmt"
 	_ "math"
 	"sort"
+	"strings"
+	"time"
 )
 
 // Statistics 统计信息
@@ -176,7 +179,7 @@ func (b *StatsBuilder) BuildIndexStats(indexName string, keys [][]interface{}) *
 // 辅助函数
 
 func getCurrentTime() int64 {
-	return 0 // TODO: 实现
+	return time.Now().Unix()
 }
 
 func calculateRowSize(row []interface{}) int64 {
@@ -188,7 +191,26 @@ func calculateRowSize(row []interface{}) int64 {
 }
 
 func calculateValueSize(v interface{}) int64 {
-	return 0 // TODO: 实现
+	switch val := v.(type) {
+	case nil:
+		return 0
+	case int8, uint8, bool:
+		return 1
+	case int16, uint16:
+		return 2
+	case int32, uint32, float32:
+		return 4
+	case int, int64, uint64, float64:
+		return 8
+	case string:
+		return int64(len(val))
+	case []byte:
+		return int64(len(val))
+	case time.Time:
+		return 8
+	default:
+		return 8
+	}
 }
 
 func buildTopN(freq map[interface{}]int64, n int) []ValueFreq {
@@ -286,11 +308,26 @@ func findMinMax(values []interface{}) (max, min interface{}) {
 }
 
 func buildIndexKey(key []interface{}) string {
-	return "" // TODO: 实现
+	parts := make([]string, len(key))
+	for i, v := range key {
+		parts[i] = fmt.Sprintf("%v", v)
+	}
+	return strings.Join(parts, "|")
 }
 
 func calculateClusterFactor(keys [][]interface{}) float64 {
-	return 0 // TODO: 实现
+	if len(keys) == 0 {
+		return 0
+	}
+
+	distinct := make(map[string]struct{})
+	for _, k := range keys {
+		distinct[buildIndexKey(k)] = struct{}{}
+	}
+	if len(distinct) == 0 {
+		return 0
+	}
+	return float64(len(keys)) / float64(len(distinct))
 }
 
 func calculateNDV(values []interface{}) int64 {
@@ -304,6 +341,114 @@ func calculateNDV(values []interface{}) int64 {
 }
 
 func less(a, b interface{}) bool {
-	// TODO: 实现值比较
+	switch va := a.(type) {
+	case int, int8, int16, int32, int64:
+		return toInt64(va) < toInt64(b)
+	case uint, uint8, uint16, uint32, uint64:
+		return toUint64(va) < toUint64(b)
+	case float32, float64:
+		return toFloat64(va) < toFloat64(b)
+	case string:
+		if vb, ok := b.(string); ok {
+			return va < vb
+		}
+	case time.Time:
+		if vb, ok := b.(time.Time); ok {
+			return va.Before(vb)
+		}
+	}
 	return false
+}
+
+func toInt64(v interface{}) int64 {
+	switch t := v.(type) {
+	case int:
+		return int64(t)
+	case int8:
+		return int64(t)
+	case int16:
+		return int64(t)
+	case int32:
+		return int64(t)
+	case int64:
+		return t
+	case uint:
+		return int64(t)
+	case uint8:
+		return int64(t)
+	case uint16:
+		return int64(t)
+	case uint32:
+		return int64(t)
+	case uint64:
+		return int64(t)
+	case float32:
+		return int64(t)
+	case float64:
+		return int64(t)
+	default:
+		return 0
+	}
+}
+
+func toUint64(v interface{}) uint64 {
+	switch t := v.(type) {
+	case uint:
+		return uint64(t)
+	case uint8:
+		return uint64(t)
+	case uint16:
+		return uint64(t)
+	case uint32:
+		return uint64(t)
+	case uint64:
+		return t
+	case int:
+		return uint64(t)
+	case int8:
+		return uint64(t)
+	case int16:
+		return uint64(t)
+	case int32:
+		return uint64(t)
+	case int64:
+		return uint64(t)
+	case float32:
+		return uint64(t)
+	case float64:
+		return uint64(t)
+	default:
+		return 0
+	}
+}
+
+func toFloat64(v interface{}) float64 {
+	switch t := v.(type) {
+	case float32:
+		return float64(t)
+	case float64:
+		return t
+	case int:
+		return float64(t)
+	case int8:
+		return float64(t)
+	case int16:
+		return float64(t)
+	case int32:
+		return float64(t)
+	case int64:
+		return float64(t)
+	case uint:
+		return float64(t)
+	case uint8:
+		return float64(t)
+	case uint16:
+		return float64(t)
+	case uint32:
+		return float64(t)
+	case uint64:
+		return float64(t)
+	default:
+		return 0
+	}
 }


### PR DESCRIPTION
## Summary
- fill in statistics helper functions for stats calculations
- allow index pushdown optimizer to merge index candidates
- implement optimizer helpers for predicate pushdown and column pruning
- add placeholder logic for subquery optimization

## Testing
- `go test ./...` *(fails: access to proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686cb7834efc8328b5ee2b83836e156e