### PR TITLE
Implement expression builders

### DIFF
--- a/server/innodb/plan/expression.go
+++ b/server/innodb/plan/expression.go
@@ -201,6 +201,14 @@ type Function struct {
 	Args []Expression
 }
 
+func (f *Function) Name() string {
+	return f.Name
+}
+
+func (f *Function) Args() []Expression {
+	return f.Args
+}
+
 func (f *Function) Eval(ctx *EvalContext) (interface{}, error) {
 	args := make([]interface{}, len(f.Args))
 	for i, arg := range f.Args {

--- a/server/innodb/plan/logical_plan.go
+++ b/server/innodb/plan/logical_plan.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/zhukovaskychina/xmysql-server/server/innodb/metadata"
 	"github.com/zhukovaskychina/xmysql-server/server/innodb/sqlparser"
+	"strconv"
+	"strings"
 )
 
 // AggregateFunc represents an aggregate function
@@ -134,6 +136,42 @@ type PlanBuilder struct {
 	infoSchema InfoSchemas
 }
 
+func (b *PlanBuilder) convertComparisonOp(op string) BinaryOp {
+	switch strings.ToLower(op) {
+	case "=":
+		return OpEQ
+	case "!=", "<>":
+		return OpNE
+	case "<":
+		return OpLT
+	case "<=":
+		return OpLE
+	case ">":
+		return OpGT
+	case ">=":
+		return OpGE
+	case "like":
+		return OpLike
+	case "in":
+		return OpIn
+	}
+	return OpEQ
+}
+
+func (b *PlanBuilder) convertBinaryOp(op string) BinaryOp {
+	switch op {
+	case "+":
+		return OpAdd
+	case "-":
+		return OpSub
+	case "*":
+		return OpMul
+	case "/":
+		return OpDiv
+	}
+	return OpAdd
+}
+
 // buildSelect 构建SELECT语句的逻辑计划
 func (b *PlanBuilder) buildSelect(stmt *sqlparser.Select) (LogicalPlan, error) {
 	// 1. 构建FROM子句
@@ -170,7 +208,7 @@ func (b *PlanBuilder) buildSelect(stmt *sqlparser.Select) (LogicalPlan, error) {
 		BaseLogicalPlan: BaseLogicalPlan{
 			children: []LogicalPlan{from},
 		},
-		Exprs: b.buildProjectionExprs(stmt.SelectExprs),
+		Exprs: b.buildProjectionExprs(stmt.SelectExprs, from.Schema()),
 	}
 
 	return projection, nil
@@ -228,24 +266,122 @@ func (b *PlanBuilder) buildTableSource(tableExpr *sqlparser.AliasedTableExpr) (L
 
 // buildExpr 构建表达式
 func (b *PlanBuilder) buildExpr(expr sqlparser.Expr) Expression {
-	// TODO: 实现表达式构建
+	switch v := expr.(type) {
+	case *sqlparser.SQLVal:
+		switch v.Type {
+		case sqlparser.IntVal:
+			if n, err := strconv.ParseInt(string(v.Val), 10, 64); err == nil {
+				return &Constant{Value: n}
+			}
+		case sqlparser.FloatVal:
+			if f, err := strconv.ParseFloat(string(v.Val), 64); err == nil {
+				return &Constant{Value: f}
+			}
+		default:
+			return &Constant{Value: string(v.Val)}
+		}
+	case *sqlparser.NullVal:
+		return &Constant{Value: nil}
+	case sqlparser.BoolVal:
+		return &Constant{Value: bool(v)}
+	case *sqlparser.ColName:
+		return &Column{Name: v.Name.String()}
+	case *sqlparser.BinaryExpr:
+		return &BinaryOperation{
+			Op:    b.convertBinaryOp(v.Operator),
+			Left:  b.buildExpr(v.Left),
+			Right: b.buildExpr(v.Right),
+		}
+	case *sqlparser.ComparisonExpr:
+		return &BinaryOperation{
+			Op:    b.convertComparisonOp(v.Operator),
+			Left:  b.buildExpr(v.Left),
+			Right: b.buildExpr(v.Right),
+		}
+	case *sqlparser.AndExpr:
+		return &BinaryOperation{Op: OpAnd, Left: b.buildExpr(v.Left), Right: b.buildExpr(v.Right)}
+	case *sqlparser.OrExpr:
+		return &BinaryOperation{Op: OpOr, Left: b.buildExpr(v.Left), Right: b.buildExpr(v.Right)}
+	case *sqlparser.FuncExpr:
+		var args []Expression
+		for _, a := range v.Exprs {
+			if ae, ok := a.(*sqlparser.AliasedExpr); ok {
+				args = append(args, b.buildExpr(ae.Expr))
+			}
+		}
+		return &Function{Name: v.Name.String(), Args: args}
+	case sqlparser.ValTuple:
+		var vals []interface{}
+		for _, e := range v {
+			if c, ok := b.buildExpr(e).(*Constant); ok {
+				vals = append(vals, c.Value)
+			}
+		}
+		return &Constant{Value: vals}
+	case *sqlparser.ParenExpr:
+		return b.buildExpr(v.Expr)
+	}
 	return nil
 }
 
 // buildGroupByItems 构建GROUP BY项
 func (b *PlanBuilder) buildGroupByItems(groupBy sqlparser.GroupBy) []Expression {
-	// TODO: 实现GROUP BY项构建
-	return nil
+	var items []Expression
+	for _, expr := range groupBy {
+		items = append(items, b.buildExpr(expr))
+	}
+	return items
 }
 
 // buildAggFuncs 构建聚合函数
 func (b *PlanBuilder) buildAggFuncs(selectExprs sqlparser.SelectExprs) []AggregateFunc {
-	// TODO: 实现聚合函数构建
-	return nil
+	var funcs []AggregateFunc
+	for _, se := range selectExprs {
+		ae, ok := se.(*sqlparser.AliasedExpr)
+		if !ok {
+			continue
+		}
+		fe, ok := ae.Expr.(*sqlparser.FuncExpr)
+		if !ok || !fe.IsAggregate() {
+			continue
+		}
+		var args []Expression
+		for _, a := range fe.Exprs {
+			if ae2, ok := a.(*sqlparser.AliasedExpr); ok {
+				args = append(args, b.buildExpr(ae2.Expr))
+			}
+		}
+		funcs = append(funcs, &Function{Name: fe.Name.String(), Args: args})
+	}
+	return funcs
 }
 
 // buildProjectionExprs 构建投影表达式
-func (b *PlanBuilder) buildProjectionExprs(selectExprs sqlparser.SelectExprs) []Expression {
-	// TODO: 实现投影表达式构建
-	return nil
+func (b *PlanBuilder) buildProjectionExprs(selectExprs sqlparser.SelectExprs, schema *metadata.DatabaseSchema) []Expression {
+	var exprs []Expression
+	for _, se := range selectExprs {
+		switch v := se.(type) {
+		case *sqlparser.AliasedExpr:
+			exprs = append(exprs, b.buildExpr(v.Expr))
+		case *sqlparser.StarExpr:
+			if schema == nil {
+				continue
+			}
+			tblName := v.TableName.Name.String()
+			if tblName != "" {
+				if tbl, ok := schema.Tables[tblName]; ok {
+					for _, col := range tbl.Columns {
+						exprs = append(exprs, &Column{Name: col.Name})
+					}
+				}
+				continue
+			}
+			for _, tbl := range schema.Tables {
+				for _, col := range tbl.Columns {
+					exprs = append(exprs, &Column{Name: col.Name})
+				}
+			}
+		}
+	}
+	return exprs
 }

--- a/server/innodb/plan/logical_plan_test.go
+++ b/server/innodb/plan/logical_plan_test.go
@@ -1,0 +1,61 @@
+package plan
+
+import (
+	"fmt"
+	"github.com/zhukovaskychina/xmysql-server/server/innodb/metadata"
+	"github.com/zhukovaskychina/xmysql-server/server/innodb/sqlparser"
+	"testing"
+)
+
+type mockInfoSchema struct{ tables map[string]*metadata.Table }
+
+func (m *mockInfoSchema) TableByName(name string) (*metadata.Table, error) {
+	if t, ok := m.tables[name]; ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("table %s not found", name)
+}
+
+func createTestTable2() *metadata.Table {
+	table := &metadata.Table{
+		Name: "users",
+		Columns: []*metadata.Column{
+			{Name: "id", DataType: metadata.TypeBigInt},
+			{Name: "name", DataType: metadata.TypeVarchar},
+		},
+	}
+	schema := metadata.NewSchema("test")
+	schema.AddTable(table)
+	return table
+}
+
+func TestBuildLogicalPlan_GroupBy(t *testing.T) {
+	table := createTestTable2()
+	schema := metadata.NewSchema("test")
+	_ = schema.AddTable(table)
+	_ = schema // avoid unused
+	info := &mockInfoSchema{tables: map[string]*metadata.Table{"users": table}}
+
+	stmt, err := sqlparser.Parse("SELECT name, COUNT(id) FROM users GROUP BY name")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	sel := stmt.(*sqlparser.Select)
+
+	planNode, err := BuildLogicalPlan(sel, info)
+	if err != nil {
+		t.Fatalf("build plan error: %v", err)
+	}
+
+	proj, ok := planNode.(*LogicalProjection)
+	if !ok {
+		t.Fatalf("expected projection")
+	}
+	agg, ok := proj.Children()[0].(*LogicalAggregation)
+	if !ok {
+		t.Fatalf("expected aggregation node")
+	}
+	if len(agg.GroupByItems) != 1 || len(agg.AggFuncs) != 1 {
+		t.Fatalf("unexpected agg content")
+	}
+}


### PR DESCRIPTION
## Summary
- map parser expressions to logical expressions
- support GROUP BY and aggregate parsing
- expand projections from schema
- unit test for GROUP BY planning

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686cc5ff96708328aa4bbbefad81628b