### PR TITLE
Implement aggregation elimination for simple MIN/MAX

### DIFF
--- a/server/innodb/plan/optimizer.go
+++ b/server/innodb/plan/optimizer.go
@@ -381,11 +381,44 @@ func buildPrunedSchema(schema *metadata.DatabaseSchema, cols []string) *metadata
 }
 
 func canEliminateAggregation(agg *LogicalAggregation, child LogicalPlan) bool {
-	// TODO: 判断是否可以消除聚合
+	// Only consider MIN/MAX without GROUP BY
+	if len(agg.GroupByItems) > 0 || len(agg.AggFuncs) != 1 {
+		return false
+	}
+
+	fn, ok := agg.AggFuncs[0].(*Function)
+	if !ok {
+		return false
+	}
+
+	name := strings.ToUpper(fn.Name)
+	if name != "MIN" && name != "MAX" {
+		return false
+	}
+
+	if len(fn.Args) != 1 {
+		return false
+	}
+
+	if _, ok := fn.Args[0].(*Column); !ok {
+		return false
+	}
+
+	switch child.(type) {
+	case *LogicalTableScan, *LogicalIndexScan:
+		return true
+	}
+
 	return false
 }
 
 func convertAggToProj(agg *LogicalAggregation) []Expression {
-	// TODO: 将聚合转换为投影表达式
-	return nil
+	if len(agg.AggFuncs) != 1 {
+		return nil
+	}
+	fn, ok := agg.AggFuncs[0].(*Function)
+	if !ok || len(fn.Args) != 1 {
+		return nil
+	}
+	return []Expression{fn.Args[0]}
 }

--- a/server/innodb/plan/optimizer_test.go
+++ b/server/innodb/plan/optimizer_test.go
@@ -1,0 +1,95 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/zhukovaskychina/xmysql-server/server/innodb/metadata"
+)
+
+func TestEliminateAggregationSimpleMax(t *testing.T) {
+	table := createTestTable()
+	schema := metadata.NewSchema("test")
+	_ = schema.AddTable(table)
+	scan := &LogicalTableScan{
+		BaseLogicalPlan: BaseLogicalPlan{schema: table.Schema},
+		Table:           table,
+	}
+
+	agg := &LogicalAggregation{
+		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{scan}},
+		GroupByItems:    nil,
+		AggFuncs: []AggregateFunc{&Function{
+			Name: "MAX",
+			Args: []Expression{&Column{Name: "id"}},
+		}},
+	}
+
+	proj := &LogicalProjection{
+		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{agg}},
+		Exprs:           []Expression{&Function{Name: "MAX", Args: []Expression{&Column{Name: "id"}}}},
+	}
+
+	optimized := OptimizeLogicalPlan(proj)
+
+	p, ok := optimized.(*LogicalProjection)
+	if !ok {
+		t.Fatalf("expected projection")
+	}
+
+	if _, ok := p.Children()[0].(*LogicalAggregation); ok {
+		t.Fatalf("aggregation not eliminated")
+	}
+
+	if len(p.Exprs) != 1 {
+		t.Fatalf("unexpected projection expr count")
+	}
+
+	col, ok := p.Exprs[0].(*Column)
+	if !ok || col.Name != "id" {
+		t.Fatalf("expected projection on id")
+	}
+}
+
+func TestEliminateAggregationSimpleMin(t *testing.T) {
+	table := createTestTable()
+	schema := metadata.NewSchema("test")
+	_ = schema.AddTable(table)
+	scan := &LogicalTableScan{
+		BaseLogicalPlan: BaseLogicalPlan{schema: table.Schema},
+		Table:           table,
+	}
+
+	agg := &LogicalAggregation{
+		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{scan}},
+		GroupByItems:    nil,
+		AggFuncs: []AggregateFunc{&Function{
+			Name: "MIN",
+			Args: []Expression{&Column{Name: "id"}},
+		}},
+	}
+
+	proj := &LogicalProjection{
+		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{agg}},
+		Exprs:           []Expression{&Function{Name: "MIN", Args: []Expression{&Column{Name: "id"}}}},
+	}
+
+	optimized := OptimizeLogicalPlan(proj)
+
+	p, ok := optimized.(*LogicalProjection)
+	if !ok {
+		t.Fatalf("expected projection")
+	}
+
+	if _, ok := p.Children()[0].(*LogicalAggregation); ok {
+		t.Fatalf("aggregation not eliminated")
+	}
+
+	if len(p.Exprs) != 1 {
+		t.Fatalf("unexpected projection expr count")
+	}
+
+	col, ok := p.Exprs[0].(*Column)
+	if !ok || col.Name != "id" {
+		t.Fatalf("expected projection on id")
+	}
+}


### PR DESCRIPTION
## Summary
- handle MIN/MAX aggregation elimination in `canEliminateAggregation`
- implement `convertAggToProj` to build projection expressions
- add unit tests covering MIN/MAX elimination

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686ce357f1848328b84cb8daec4e4d1d