### PR TITLE
Fix compile error from conflicting Function fields2

### DIFF
--- a/server/innodb/plan/cost_model_test.go
+++ b/server/innodb/plan/cost_model_test.go
@@ -111,7 +111,7 @@ func TestHashAggCost(t *testing.T) {
 			},
 		},
 		GroupByItems: []Expression{&Column{Name: "id"}},
-		AggFuncs:     []AggregateFunc{&Function{Name: "COUNT"}},
+		AggFuncs:     []AggregateFunc{&Function{FuncName: "COUNT"}},
 	}
 
 	cost := model.hashAggCost(plan)
@@ -248,7 +248,7 @@ func TestCompositePlanCost(t *testing.T) {
 						},
 					},
 					GroupByItems: []Expression{&Column{Name: "id"}},
-					AggFuncs:     []AggregateFunc{&Function{Name: "COUNT"}},
+					AggFuncs:     []AggregateFunc{&Function{FuncName: "COUNT"}},
 				},
 			},
 		},

--- a/server/innodb/plan/expression.go
+++ b/server/innodb/plan/expression.go
@@ -197,21 +197,21 @@ func (b *BinaryOperation) convertOperatorToString() string {
 // Function 函数表达式
 type Function struct {
 	BaseExpression
-	Name string
-	Args []Expression
+	FuncName string
+	FuncArgs []Expression
 }
 
 func (f *Function) Name() string {
-	return f.Name
+	return f.FuncName
 }
 
 func (f *Function) Args() []Expression {
-	return f.Args
+	return f.FuncArgs
 }
 
 func (f *Function) Eval(ctx *EvalContext) (interface{}, error) {
-	args := make([]interface{}, len(f.Args))
-	for i, arg := range f.Args {
+	args := make([]interface{}, len(f.FuncArgs))
+	for i, arg := range f.FuncArgs {
 		val, err := arg.Eval(ctx)
 		if err != nil {
 			return nil, err
@@ -219,7 +219,7 @@ func (f *Function) Eval(ctx *EvalContext) (interface{}, error) {
 		args[i] = val
 	}
 
-	switch f.Name {
+	switch f.FuncName {
 	case "COUNT":
 		return evalCount(args)
 	case "SUM":
@@ -237,16 +237,16 @@ func (f *Function) Eval(ctx *EvalContext) (interface{}, error) {
 	case "NOW":
 		return time.Now(), nil
 	default:
-		return nil, fmt.Errorf("unknown function: %s", f.Name)
+		return nil, fmt.Errorf("unknown function: %s", f.FuncName)
 	}
 }
 
 func (f *Function) String() string {
-	args := make([]string, len(f.Args))
-	for i, arg := range f.Args {
+	args := make([]string, len(f.FuncArgs))
+	for i, arg := range f.FuncArgs {
 		args[i] = arg.String()
 	}
-	return fmt.Sprintf("%s(%s)", f.Name, strings.Join(args, ", "))
+	return fmt.Sprintf("%s(%s)", f.FuncName, strings.Join(args, ", "))
 }
 
 // 运算符求值函数

--- a/server/innodb/plan/expression_test.go
+++ b/server/innodb/plan/expression_test.go
@@ -210,8 +210,8 @@ func TestFunction(t *testing.T) {
 
 			expr := &Function{
 				BaseExpression: BaseExpression{},
-				Name:           tt.fn,
-				Args:           args,
+				FuncName:       tt.fn,
+				FuncArgs:       args,
 			}
 
 			ctx := &EvalContext{}
@@ -255,8 +255,8 @@ func TestExpressionString(t *testing.T) {
 		{
 			name: "Function",
 			expr: &Function{
-				Name: "COUNT",
-				Args: []Expression{&Column{Name: "id"}},
+				FuncName: "COUNT",
+				FuncArgs: []Expression{&Column{Name: "id"}},
 			},
 			want: "COUNT(id)",
 		},

--- a/server/innodb/plan/logical_plan.go
+++ b/server/innodb/plan/logical_plan.go
@@ -309,7 +309,7 @@ func (b *PlanBuilder) buildExpr(expr sqlparser.Expr) Expression {
 				args = append(args, b.buildExpr(ae.Expr))
 			}
 		}
-		return &Function{Name: v.Name.String(), Args: args}
+		return &Function{FuncName: v.Name.String(), FuncArgs: args}
 	case sqlparser.ValTuple:
 		var vals []interface{}
 		for _, e := range v {
@@ -351,7 +351,7 @@ func (b *PlanBuilder) buildAggFuncs(selectExprs sqlparser.SelectExprs) []Aggrega
 				args = append(args, b.buildExpr(ae2.Expr))
 			}
 		}
-		funcs = append(funcs, &Function{Name: fe.Name.String(), Args: args})
+		funcs = append(funcs, &Function{FuncName: fe.Name.String(), FuncArgs: args})
 	}
 	return funcs
 }

--- a/server/innodb/plan/optimizer.go
+++ b/server/innodb/plan/optimizer.go
@@ -391,16 +391,16 @@ func canEliminateAggregation(agg *LogicalAggregation, child LogicalPlan) bool {
 		return false
 	}
 
-	name := strings.ToUpper(fn.Name)
+	name := strings.ToUpper(fn.Name())
 	if name != "MIN" && name != "MAX" {
 		return false
 	}
 
-	if len(fn.Args) != 1 {
+	if len(fn.Args()) != 1 {
 		return false
 	}
 
-	if _, ok := fn.Args[0].(*Column); !ok {
+	if _, ok := fn.Args()[0].(*Column); !ok {
 		return false
 	}
 
@@ -417,8 +417,8 @@ func convertAggToProj(agg *LogicalAggregation) []Expression {
 		return nil
 	}
 	fn, ok := agg.AggFuncs[0].(*Function)
-	if !ok || len(fn.Args) != 1 {
+	if !ok || len(fn.Args()) != 1 {
 		return nil
 	}
-	return []Expression{fn.Args[0]}
+	return []Expression{fn.Args()[0]}
 }

--- a/server/innodb/plan/optimizer_test.go
+++ b/server/innodb/plan/optimizer_test.go
@@ -26,7 +26,7 @@ func TestEliminateAggregationSimpleMax(t *testing.T) {
 
 	proj := &LogicalProjection{
 		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{agg}},
-		Exprs:           []Expression{&Function{Name: "MAX", Args: []Expression{&Column{Name: "id"}}}},
+		Exprs:           []Expression{&Function{FuncName: "MAX", FuncArgs: []Expression{&Column{Name: "id"}}}},
 	}
 
 	optimized := OptimizeLogicalPlan(proj)
@@ -63,14 +63,14 @@ func TestEliminateAggregationSimpleMin(t *testing.T) {
 		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{scan}},
 		GroupByItems:    nil,
 		AggFuncs: []AggregateFunc{&Function{
-			Name: "MIN",
-			Args: []Expression{&Column{Name: "id"}},
+			FuncName: "MIN",
+			FuncArgs: []Expression{&Column{Name: "id"}},
 		}},
 	}
 
 	proj := &LogicalProjection{
 		BaseLogicalPlan: BaseLogicalPlan{children: []LogicalPlan{agg}},
-		Exprs:           []Expression{&Function{Name: "MIN", Args: []Expression{&Column{Name: "id"}}}},
+		Exprs:           []Expression{&Function{FuncName: "MIN", FuncArgs: []Expression{&Column{Name: "id"}}}},
 	}
 
 	optimized := OptimizeLogicalPlan(proj)


### PR DESCRIPTION
## Summary
- resolve field/method name conflict in `Function` by renaming to `FuncName` and `FuncArgs`
- update optimizer and plan builder to use new names
- update related tests accordingly

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686cc2feed2083289728693d6c0c6e08