### PR TITLE
Fix compile issues with missing structs

### DIFF
--- a/server/innodb/basic/btree_statistics.go
+++ b/server/innodb/basic/btree_statistics.go
@@ -1,0 +1,8 @@
+package basic
+
+// BTreeStatistics represents statistics for a B+Tree.
+type BTreeStatistics struct {
+	LeafPages    uint32
+	NonLeafPages uint32
+	RecordCount  uint64
+}

--- a/server/innodb/integration/sql_parser_integration.go
+++ b/server/innodb/integration/sql_parser_integration.go
@@ -19,9 +19,6 @@ import (
 type SQLParserIntegrator struct {
 	sync.RWMutex
 
-	// 解析器组件
-	parser *sqlparser.Parser
-
 	// 优化器组件
 	optimizerManager    *manager.OptimizerManager
 	storageIntegrator   *StorageEngineIntegrator
@@ -73,8 +70,7 @@ func NewSQLParserIntegrator(
 
 // initializeIntegration 初始化集成组件
 func (spi *SQLParserIntegrator) initializeIntegration() {
-	// 初始化解析器
-	spi.parser = &sqlparser.Parser{}
+	// 初始化解析器 (使用sqlparser包提供的全局解析函数)
 
 	// 获取优化器组件
 	spi.statisticsCollector = spi.storageIntegrator.statisticsCollector
@@ -415,7 +411,7 @@ func (spi *SQLParserIntegrator) convertValueExpression(
 }
 
 // convertOperator 转换操作符
-func (spi *SQLParserIntegrator) convertOperator(operator string) (plan.Operator, error) {
+func (spi *SQLParserIntegrator) convertOperator(operator string) (plan.BinaryOp, error) {
 	switch operator {
 	case "=":
 		return plan.OpEQ, nil

--- a/server/innodb/manager/buffer_pool_manager_optimized.go
+++ b/server/innodb/manager/buffer_pool_manager_optimized.go
@@ -375,6 +375,25 @@ func (bpm *OptimizedBufferPoolManager) GetStats() map[string]interface{} {
 	}
 }
 
+// GetStatistics returns BufferPoolStatistics in a structured form.
+func (bpm *OptimizedBufferPoolManager) GetStatistics() *BufferPoolStatistics {
+	return &BufferPoolStatistics{
+		Hits:          atomic.LoadUint64(&bpm.stats.hits),
+		Misses:        atomic.LoadUint64(&bpm.stats.misses),
+		Evictions:     atomic.LoadUint64(&bpm.stats.evictions),
+		Flushes:       atomic.LoadUint64(&bpm.stats.flushes),
+		PageReads:     atomic.LoadUint64(&bpm.stats.pageReads),
+		PageWrites:    atomic.LoadUint64(&bpm.stats.pageWrites),
+		YoungHits:     atomic.LoadUint64(&bpm.stats.youngHits),
+		OldHits:       atomic.LoadUint64(&bpm.stats.oldHits),
+		DirtyPages:    atomic.LoadUint64(&bpm.stats.dirtyPages),
+		TotalPages:    atomic.LoadUint64(&bpm.stats.totalPages),
+		BackgroundOps: atomic.LoadUint64(&bpm.stats.backgroundOps),
+		HitRate:       bpm.calculateHitRate(),
+		CacheSize:     bpm.lruCache.Len(),
+	}
+}
+
 // calculateHitRate 计算缓存命中率
 func (bpm *OptimizedBufferPoolManager) calculateHitRate() float64 {
 	hits := atomic.LoadUint64(&bpm.stats.hits)

--- a/server/innodb/manager/buffer_pool_statistics.go
+++ b/server/innodb/manager/buffer_pool_statistics.go
@@ -1,0 +1,18 @@
+package manager
+
+// BufferPoolStatistics represents basic statistics of the buffer pool.
+type BufferPoolStatistics struct {
+	Hits          uint64
+	Misses        uint64
+	Evictions     uint64
+	Flushes       uint64
+	PageReads     uint64
+	PageWrites    uint64
+	YoungHits     uint64
+	OldHits       uint64
+	DirtyPages    uint64
+	TotalPages    uint64
+	BackgroundOps uint64
+	HitRate       float64
+	CacheSize     int
+}

--- a/server/innodb/manager/storage_manager.go
+++ b/server/innodb/manager/storage_manager.go
@@ -194,6 +194,31 @@ func (sm *StorageManager) GetSystemVariableAnalyzer() *SystemVariableAnalyzer {
 	return sm.sysVarAnalyzer
 }
 
+// GetBTreeManager returns the B+Tree manager if available.
+func (sm *StorageManager) GetBTreeManager() basic.BPlusTreeManager {
+	return nil
+}
+
+// GetTableManager returns the table manager if available.
+func (sm *StorageManager) GetTableManager() *TableManager {
+	return nil
+}
+
+// GetIndexManager returns the index manager if available.
+func (sm *StorageManager) GetIndexManager() *IndexManager {
+	return nil
+}
+
+// GetTransactionManager returns the transaction manager if available.
+func (sm *StorageManager) GetTransactionManager() *TransactionManager {
+	return nil
+}
+
+// GetTableStorageManager returns the table storage manager if available.
+func (sm *StorageManager) GetTableStorageManager() *TableStorageManager {
+	return nil
+}
+
 func (sm *StorageManager) OpenSpace(spaceID uint32) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()

--- a/server/innodb/plan/space_statistics.go
+++ b/server/innodb/plan/space_statistics.go
@@ -1,0 +1,9 @@
+package plan
+
+// SpaceStatistics holds basic statistics for a tablespace.
+type SpaceStatistics struct {
+	SpaceID     uint32
+	PageCount   uint32
+	ExtentCount uint32
+	UsedSpace   uint64
+}


### PR DESCRIPTION
## Summary
- remove unused sqlparser Parser field
- add missing statistics types for plan, manager and basic packages
- expose BufferPool statistics accessor
- stub out storage manager accessors for compilation

## Testing
- `go vet ./...` *(fails: Fetch from proxy.golang.org forbidden)*
- `go test ./...` *(fails: Fetch from proxy.golang.org forbidden)*
- `go build ./...` *(fails: Fetch from proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686ce94679288328a8c9c4ab5be65886